### PR TITLE
Support extra services in docker-compose.yml

### DIFF
--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -4,6 +4,9 @@
 {% endif %}
 version: '3'
 services:
+{% if @('extra_services') %}
+{{ to_yaml(@('extra_services')) | raw }}
+{% endif %}
   chrome:
     build: docker/image/chrome
     networks:

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -1,0 +1,3 @@
+function('to_yaml', [text]): |
+  #!php
+  = preg_replace('/^/m', '  ', \Symfony\Component\Yaml\Yaml::dump($text, 100, 2));


### PR DESCRIPTION
Brings in https://github.com/inviqa/harness-node/commit/7b7c310da247a1bf0077ac3f24d71c4df16b9abc to support arbitrary services in docker-compose.yml