### PR TITLE
Stop redis getting a traefik host

### DIFF
--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -107,6 +107,7 @@ services:
   redis:
     image: redis:4-alpine
     labels:
+      - traefik.enable=false
       - co.elastic.logs/module=redis
     networks:
       - private


### PR DESCRIPTION
 Removed in 4e5a85f90fbeb7131e30a4daf027956d57b65bbf by mistake