### PR TITLE
Split sessions into separate redis instance

### DIFF
--- a/application/overlay/app/etc/_twig/env.php/session/redis.twig
+++ b/application/overlay/app/etc/_twig/env.php/session/redis.twig
@@ -1,8 +1,8 @@
   [
       'save'  => 'redis',
       'redis' => [
-          'host'                  => getenv('REDIS_HOST')?:'redis',
-          'port'                  => getenv('REDIS_PORT')?:'6379',
+          'host'                  => getenv('REDIS_SESSION_HOST')?:'redis-session',
+          'port'                  => getenv('REDIS_SESSION_PORT')?:'6379',
           'password'              => '',
           'timeout'               => '2.5',
           'persistent_identifier' => '',

--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -109,6 +109,8 @@ services:
       - shared
   redis:
     image: redis:4-alpine
+    # 1GB; evict any least recently used key even if they don't have a TTL
+    command: redis-server --maxmemory 1073742000 --maxmemory-policy allkeys-lru
     labels:
       - traefik.enable=false
       - co.elastic.logs/module=redis
@@ -117,7 +119,10 @@ services:
       - shared
   redis-session:
     image: redis:4-alpine
+    # 1GB; evict key that would expire soonest
+    command: redis-server --maxmemory 1073742000 --maxmemory-policy volatile-ttl
     labels:
+      - traefik.enable=false
       - co.elastic.logs/module=redis
     networks:
       - private

--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -47,6 +47,7 @@ services:
     links:
       - mysql:mysql
       - redis:redis
+      - redis-session:redis-session
     networks:
       - private
   nginx:
@@ -86,6 +87,7 @@ services:
     links:
       - mysql:mysql
       - redis:redis
+      - redis-session:redis-session
     environment:
       <<: *APP_ENV_VARS
   mysql:
@@ -109,6 +111,13 @@ services:
     image: redis:4-alpine
     labels:
       - traefik.enable=false
+      - co.elastic.logs/module=redis
+    networks:
+      - private
+      - shared
+  redis-session:
+    image: redis:4-alpine
+    labels:
       - co.elastic.logs/module=redis
     networks:
       - private


### PR DESCRIPTION
Separate instance allows us to expire cache and sessions in a different way once their maxmemory has been reached:

* Evicts sessions that would expire soonest (php-redis-session-abstract has low TTL for bots, for example).
* Evicts cache entries that have been used least recently, even though magento doesn't set a TTL for full page cache entries.